### PR TITLE
Added new features, fixed coding style

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,16 @@
+<?php
+
+return Symfony\CS\Config\Config::create()
+    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
+    ->fixers([
+        '-concat_without_spaces',
+        'concat_with_spaces',
+        'phpdoc_order',
+        'short_array_syntax',
+    ])
+    ->finder(
+        Symfony\CS\Finder\DefaultFinder::create()
+            ->exclude(['var', 'vendor'])
+            ->in(__DIR__)
+    )
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ This is a dead-simple DocBlock / doc comment / PHPDoc parser.  It separates a bl
 Use Composer to install by adding this to your `composer.json`:
 
 ```
-    "require": {
-        "kamermans/docblock-reflection": "~1.0"
-    }
+	"require": {
+		"kamermans/docblock-reflection": "~1.0"
+	}
 ```
 
 ## Usage ##

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,10 @@
         {
             "name": "Steve Kamerman",
             "email": "stevekamerman@gmail.com"
+        },
+        {
+            "name": "Christan Sciberras",
+            "email": "christian@sciberras.me"
         }
     ],
     "license": "MPL",
@@ -13,7 +17,8 @@
     },
     "require-dev": {
         "php": ">=5.4",
-        "phpunit/phpunit": "~4.3"
+        "phpunit/phpunit": "~4.3",
+        "fabpot/php-cs-fixer": "^1.11"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,11 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "35921b9b035d6bd1b741d3231b495062",
+    "hash": "b66bb53ff810941ac26fc330e85a46f2",
+    "content-hash": "797126bb005a517831ee424a1efc1308",
     "packages": [],
     "packages-dev": [
         {
@@ -60,6 +61,60 @@
                 "instantiate"
             ],
             "time": "2014-10-13 12:58:55"
+        },
+        {
+            "name": "fabpot/php-cs-fixer",
+            "version": "v1.11.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
+                "reference": "41f70154642ec0f9ea9ea9c290943f3b5dfa76fc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/41f70154642ec0f9ea9ea9c290943f3b5dfa76fc",
+                "reference": "41f70154642ec0f9ea9ea9c290943f3b5dfa76fc",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.6",
+                "sebastian/diff": "~1.1",
+                "symfony/console": "~2.3|~3.0",
+                "symfony/event-dispatcher": "~2.1|~3.0",
+                "symfony/filesystem": "~2.1|~3.0",
+                "symfony/finder": "~2.1|~3.0",
+                "symfony/process": "~2.3|~3.0",
+                "symfony/stopwatch": "~2.5|~3.0"
+            },
+            "require-dev": {
+                "satooshi/php-coveralls": "0.7.*@dev"
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\CS\\": "Symfony/CS/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "time": "2016-02-26 07:37:29"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -704,6 +759,381 @@
             "time": "2014-03-07 15:35:33"
         },
         {
+            "name": "symfony/console",
+            "version": "v3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "2ed5e2706ce92313d120b8fe50d1063bcfd12e04"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/2ed5e2706ce92313d120b8fe50d1063bcfd12e04",
+                "reference": "2ed5e2706ce92313d120b8fe50d1063bcfd12e04",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/event-dispatcher": "~2.8|~3.0",
+                "symfony/process": "~2.8|~3.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-02-28 16:24:34"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "4dd5df31a28c0f82b41cb1e1599b74b5dcdbdafa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/4dd5df31a28c0f82b41cb1e1599b74b5dcdbdafa",
+                "reference": "4dd5df31a28c0f82b41cb1e1599b74b5dcdbdafa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.8|~3.0",
+                "symfony/dependency-injection": "~2.8|~3.0",
+                "symfony/expression-language": "~2.8|~3.0",
+                "symfony/stopwatch": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-01-27 05:14:46"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "23ae8f9648d0a7fe94a47c8e20e5bf37c489a451"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/23ae8f9648d0a7fe94a47c8e20e5bf37c489a451",
+                "reference": "23ae8f9648d0a7fe94a47c8e20e5bf37c489a451",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-02-23 15:16:06"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "623bda0abd9aa29e529c8e9c08b3b84171914723"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/623bda0abd9aa29e529c8e9c08b3b84171914723",
+                "reference": "623bda0abd9aa29e529c8e9c08b3b84171914723",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-01-27 05:14:46"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "1289d16209491b584839022f29257ad859b8532d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/1289d16209491b584839022f29257ad859b8532d",
+                "reference": "1289d16209491b584839022f29257ad859b8532d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-01-20 09:13:37"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "dfecef47506179db2501430e732adbf3793099c8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/dfecef47506179db2501430e732adbf3793099c8",
+                "reference": "dfecef47506179db2501430e732adbf3793099c8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-02-02 13:44:19"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "4a204804952ff267ace88cf499e0b4bb302a475e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/4a204804952ff267ace88cf499e0b4bb302a475e",
+                "reference": "4a204804952ff267ace88cf499e0b4bb302a475e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Stopwatch Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-01-03 15:35:16"
+        },
+        {
             "name": "symfony/yaml",
             "version": "v2.5.5",
             "target-dir": "Symfony/Component/Yaml",
@@ -755,8 +1185,11 @@
     "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
         "php": ">=5.3"
     },
-    "platform-dev": []
+    "platform-dev": {
+        "php": ">=5.4"
+    }
 }

--- a/examples/usage.php
+++ b/examples/usage.php
@@ -2,34 +2,39 @@
 
 use kamermans\Reflection\DocBlock;
 
-require_once __DIR__.'/../vendor/autoload.php';
+require_once __DIR__ . '/../vendor/autoload.php';
 
 /**
- * A Foo class
+ * A Foo class.
  * 
  * @deprecated
+ *
  * @version      v1.1
+ *
  * @see          Foo::bar()
  * @see          google.com
  */
-class Foo {
+class Foo
+{
     /**
      * Does something that is really
-     * cool and makes your life easy
+     * cool and makes your life easy.
      * 
      * @param string $name Your name
+     *
      * @return string
      */
-    public function bar($name) {
+    public function bar($name)
+    {
         return "FooBar $name";
     }
 }
 
-$reflect = new ReflectionClass("Foo");
+$reflect = new ReflectionClass('Foo');
 $doc = new DocBlock($reflect);
 
 echo "## Comment ##\n";
-echo $doc->getComment()."\n\n";
+echo $doc->getComment() . "\n\n";
 
 echo "## Tags ##\n";
 var_export($doc->getTags());

--- a/test/resources/test.php
+++ b/test/resources/test.php
@@ -1,60 +1,76 @@
 <?php
 /**
- * Page-level docblock
+ * Page-level docblock.
  */
 
 /**
- * Addition
+ * Addition.
+ *
  * @example
  */
-trait Add {
-	/**
-	 * Adds a number
-	 * @param numeric $number
-	 * @return object this 
-	 */
-	public function add($number) {
-		$this->number += $number;
-		return $this;
-	}
+trait Add
+{
+    /**
+     * Adds a number.
+     *
+     * @param numeric $number
+     *
+     * @return object this 
+     */
+    public function add($number)
+    {
+        $this->number += $number;
+
+        return $this;
+    }
 }
 
 /**
- * Subtraction
+ * Subtraction.
+ *
  * @deprecated
  */
-trait Subtract {
-	/**
-	 * Subtracts a number
-	 * @param  numeric $number
-	 * @return object this
-	 * @deprecated
-	 */
-	public function subtract($number) {
-		$this->number -= $number;
-		return $this;
-	}
+trait Subtract
+{
+    /**
+     * Subtracts a number.
+     *
+     * @param numeric $number
+     *
+     * @return object this
+     *
+     * @deprecated
+     */
+    public function subtract($number)
+    {
+        $this->number -= $number;
+
+        return $this;
+    }
 }
 
 /**
- * Holder of a number
+ * Holder of a number.
+ *
  * @author 		Steve Kamerman
  * @copyright   Copyright (c) 2014 The General Public
  */
-abstract class NumberHolder {
-	protected $number;
+abstract class NumberHolder
+{
+    protected $number;
 }
 
 /**
- * Supports math operations
+ * Supports math operations.
  */
-interface Mathable {
-	public function add($number);
-	public function subtract($number);
+interface Mathable
+{
+    public function add($number);
+    public function subtract($number);
 }
 
 /**
- * A Number
+ * A Number.
  *
  * example:
  * <code>
@@ -63,59 +79,78 @@ interface Mathable {
  * echo $number->add(10)->subtract(4);
  * ?>
  * </code>
+ *
  * @version    v2.1-beta3
+ *
  * @see        Mathable::add()
  * @see        Mathable::subtract()
  */
-class Number extends NumberHolder implements Mathable {
-	
-	use Add;
-	use Subtract;
+class Number extends NumberHolder implements Mathable
+{
+    use Add;
+    use Subtract;
 
-	/**
-	 * The number
-	 * @var numeric
-	 */
-	protected $number;
+    /**
+     * The number.
+     *
+     * @var numeric
+     */
+    protected $number;
 
-	/**
-	 * Constructs a new Number
-	 * @param numeric $number initial value
-	 */
-	public function __construct($number) {
-		$this->number = $number;
-	}
+    /** @var numeric */
+    protected $unusedNumber;
 
-	/**
-	 * Get the value
-	 * @return numeric value
-	 */
-	public function value() {
-		return $this->number;
-	}
+    /**
+     * Constructs a new Number.
+     *
+     * @param numeric $number initial value
+     */
+    public function __construct($number)
+    {
+        $this->number = $number;
+    }
 
-	public function __toString() {
-		return (string)$this->value();
-	}
+    /**
+     * Get the value.
+     *
+     * @return numeric value
+     */
+    public function value()
+    {
+        return $this->number;
+    }
 
-	/**
-	 * Creates a Number from a string
-	 * @param  string $number
-	 * @return Number
-	 */
-	public static function createFromString($number) {
-		return new self((float)$number);
-	}
+    public function __toString()
+    {
+        return (string) $this->value();
+    }
 
-	/**
-	 * Compare two Numbers
-	 * @param  Number $a First number
-	 * @param  Number $b Second number
-	 * @return int 0 if equal, 1 of $b is greater, -1 if $a is greater
-	 */
-	public static function compare(Number $a, Number $b) {
-		if ($a->value() == $b->value()) return 0;
-		return ($b->value() > $a->value())? 1: -1;
-	}
+    /**
+     * Creates a Number from a string.
+     *
+     * @param string $number
+     *
+     * @return Number
+     */
+    public static function createFromString($number)
+    {
+        return new self((float) $number);
+    }
 
+    /**
+     * Compare two Numbers.
+     *
+     * @param Number $a First number
+     * @param Number $b Second number
+     *
+     * @return int 0 if equal, 1 of $b is greater, -1 if $a is greater
+     */
+    public static function compare(Number $a, Number $b)
+    {
+        if ($a->value() == $b->value()) {
+            return 0;
+        }
+
+        return ($b->value() > $a->value()) ? 1 : -1;
+    }
 }

--- a/test/src/DocBlockTest.php
+++ b/test/src/DocBlockTest.php
@@ -3,186 +3,204 @@
 namespace kamermans\Reflection\Test;
 
 use kamermans\Reflection\DocBlock;
-
 use Number;
 use NumberHolder;
 use Mathable;
 use Add;
 use Subtract;
-
 use ReflectionClass;
 use ReflectionObject;
-use ReflectionMethod;
 
-class DocBlockTest extends \PHPUnit_Framework_TestCase {
+class DocBlockTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        require_once __DIR__ . '/../resources/test.php';
+    }
 
-	public function setUp() {
-		require_once __DIR__."/../resources/test.php";
-	}
+    public function testNumberExample()
+    {
+        /*
+         * I know this is a worthless test, but hey, it would be nice
+         * to know that the code works, wouldn't it?
+         */
 
-	public function testNumberExample() {
-		/*
-		 * I know this is a worthless test, but hey, it would be nice
-		 * to know that the code works, wouldn't it?
-		 */
-		
-		$number = new Number(2);
-		$this->assertSame(8, $number->add(10)->subtract(4)->value());
-		$this->assertSame("14", (string)$number->add(10)->subtract(4));
-	}
+        $number = new Number(2);
+        $this->assertSame(8, $number->add(10)->subtract(4)->value());
+        $this->assertSame('14', (string) $number->add(10)->subtract(4));
+    }
 
-	public function testConstructor() {
-		// Class
-		$doc = new DocBlock(new ReflectionClass("Number"));
-		// Object
-		$doc = new DocBlock(new ReflectionObject(new Number(1)));
-		// Interface
-		$doc = new DocBlock(new ReflectionClass("Mathable"));
-		// Abstract Class
-		$doc = new DocBlock(new ReflectionClass("NumberHolder"));
-		// Trait
-		$doc = new DocBlock(new ReflectionClass("Add"));
+    public function testConstructor()
+    {
+        // Class
+        $doc = new DocBlock(new ReflectionClass('Number'));
+        // Object
+        $doc = new DocBlock(new ReflectionObject(new Number(1)));
+        // Interface
+        $doc = new DocBlock(new ReflectionClass('Mathable'));
+        // Abstract Class
+        $doc = new DocBlock(new ReflectionClass('NumberHolder'));
+        // Trait
+        $doc = new DocBlock(new ReflectionClass('Add'));
 
-		$num = new Number(1);
-		$refl = new ReflectionObject($num);
+        $num = new Number(1);
+        $refl = new ReflectionObject($num);
 
-		// Method
-		$doc = new DocBlock($refl->getMethod("value"));
-		// Static Method
-		$doc = new DocBlock($refl->getMethod("createFromString"));
-		// Trait-Imported Method
-		$doc = new DocBlock($refl->getMethod("add"));
-		// Property
-		$doc = new DocBlock($refl->getProperty("number"));
-	}
+        // Method
+        $doc = new DocBlock($refl->getMethod('value'));
+        // Static Method
+        $doc = new DocBlock($refl->getMethod('createFromString'));
+        // Trait-Imported Method
+        $doc = new DocBlock($refl->getMethod('add'));
+        // Property
+        $doc = new DocBlock($refl->getProperty('number'));
 
-	public function testGetComment() {
-		$number_comment = "A Number\nexample:\n<code>\n<?php\n\$number = new Number(2);\necho \$number->add(10)->subtract(4);\n?>\n</code>";
-		// Class
-		$doc = new DocBlock(new ReflectionClass("Number"));
-		$this->assertSame($number_comment, $doc->getComment());
-		// Object
-		$doc = new DocBlock(new ReflectionObject(new Number(1)));
-		$this->assertSame($number_comment, $doc->getComment());
-		// Interface
-		$doc = new DocBlock(new ReflectionClass("Mathable"));
-		$this->assertSame("Supports math operations", $doc->getComment());
-		// Abstract Class
-		$doc = new DocBlock(new ReflectionClass("NumberHolder"));
-		$this->assertSame("Holder of a number", $doc->getComment());
-		// Trait
-		$doc = new DocBlock(new ReflectionClass("Add"));
-		$this->assertSame("Addition", $doc->getComment());
+        // String
+        $doc = new DocBlock("/**\n * A test comment.\n */");
+    }
 
-		$num = new Number(1);
-		$refl = new ReflectionObject($num);
+    public function testGetComment()
+    {
+        $number_comment = "A Number.\nexample:\n<code>\n<?php\n\$number = new Number(2);\necho \$number->add(10)->subtract(4);\n?>\n</code>";
+        // Class
+        $doc = new DocBlock(new ReflectionClass('Number'));
+        $this->assertSame($number_comment, $doc->getComment());
+        // Object
+        $doc = new DocBlock(new ReflectionObject(new Number(1)));
+        $this->assertSame($number_comment, $doc->getComment());
+        // Interface
+        $doc = new DocBlock(new ReflectionClass('Mathable'));
+        $this->assertSame('Supports math operations.', $doc->getComment());
+        // Abstract Class
+        $doc = new DocBlock(new ReflectionClass('NumberHolder'));
+        $this->assertSame('Holder of a number.', $doc->getComment());
+        // Trait
+        $doc = new DocBlock(new ReflectionClass('Add'));
+        $this->assertSame('Addition.', $doc->getComment());
 
-		// Method
-		$doc = new DocBlock($refl->getMethod("value"));
-		$this->assertSame("Get the value", $doc->getComment());
-		// Static Method
-		$doc = new DocBlock($refl->getMethod("createFromString"));
-		$this->assertSame("Creates a Number from a string", $doc->getComment());
-		// Trait-Imported Method
-		$doc = new DocBlock($refl->getMethod("add"));
-		$this->assertSame("Adds a number", $doc->getComment());
-		// Property
-		$doc = new DocBlock($refl->getProperty("number"));
-		$this->assertSame("The number", $doc->getComment());
-	}
+        $num = new Number(1);
+        $refl = new ReflectionObject($num);
 
-	public function testGetter() {
-		// Class
-		$doc = new DocBlock(new ReflectionClass("Number"));
-		$this->assertSame("v2.1-beta3", $doc->version);
-		$this->assertSame([
-			"Mathable::add()",
-			"Mathable::subtract()",
-		], $doc->see);
+        // Method
+        $doc = new DocBlock($refl->getMethod('value'));
+        $this->assertSame('Get the value.', $doc->getComment());
+        // Static Method
+        $doc = new DocBlock($refl->getMethod('createFromString'));
+        $this->assertSame('Creates a Number from a string.', $doc->getComment());
+        // Trait-Imported Method
+        $doc = new DocBlock($refl->getMethod('add'));
+        $this->assertSame('Adds a number.', $doc->getComment());
+        // Property
+        $doc = new DocBlock($refl->getProperty('number'));
+        $this->assertSame('The number.', $doc->getComment());
+    }
 
-		// Object
-		$doc = new DocBlock(new ReflectionObject(new Number(1)));
-		$this->assertSame("v2.1-beta3", $doc->version);
+    public function testGetter()
+    {
+        // Class
+        $doc = new DocBlock(new ReflectionClass('Number'));
+        $this->assertSame('v2.1-beta3', $doc->version);
+        $this->assertSame([
+            'Mathable::add()',
+            'Mathable::subtract()',
+        ], $doc->see);
 
-		// Interface
-		$doc = new DocBlock(new ReflectionClass("Mathable"));
-		$this->assertSame(null, $doc->foo);
+        // Object
+        $doc = new DocBlock(new ReflectionObject(new Number(1)));
+        $this->assertSame('v2.1-beta3', $doc->version);
 
-		// Abstract Class
-		$doc = new DocBlock(new ReflectionClass("NumberHolder"));
-		$this->assertSame("Steve Kamerman", $doc->author);
-		$this->assertSame("Copyright (c) 2014 The General Public", $doc->copyright);
+        // Interface
+        $doc = new DocBlock(new ReflectionClass('Mathable'));
+        $this->assertSame(null, $doc->foo);
 
-		// Trait
-		$doc = new DocBlock(new ReflectionClass("Subtract"));
-		$this->assertSame("", $doc->deprecated);
+        // Abstract Class
+        $doc = new DocBlock(new ReflectionClass('NumberHolder'));
+        $this->assertSame('Steve Kamerman', $doc->author);
+        $this->assertSame('Copyright (c) 2014 The General Public', $doc->copyright);
 
-		$num = new Number(1);
-		$refl = new ReflectionObject($num);
+        // Trait
+        $doc = new DocBlock(new ReflectionClass('Subtract'));
+        $this->assertSame('', $doc->deprecated);
 
-		// Method
-		$doc = new DocBlock($refl->getMethod("value"));
-		$this->assertSame("numeric value", $doc->return);
+        $num = new Number(1);
+        $refl = new ReflectionObject($num);
 
-		$doc = new DocBlock($refl->getMethod("__construct"));
-		$this->assertSame("numeric \$number initial value", $doc->param);
+        // Method
+        $doc = new DocBlock($refl->getMethod('value'));
+        $this->assertSame('numeric value', $doc->return);
 
-		// Static Method
-		$doc = new DocBlock($refl->getMethod("compare"));
-		$this->assertSame([
-			"Number \$a First number",
-			"Number \$b Second number",
-		], $doc->param);
+        $doc = new DocBlock($refl->getMethod('__construct'));
+        $this->assertSame('numeric $number initial value', $doc->param);
 
-		// Trait-Imported Method
-		$doc = new DocBlock($refl->getMethod("add"));
-		$this->assertSame("object this", $doc->return);
+        // Static Method
+        $doc = new DocBlock($refl->getMethod('compare'));
+        $this->assertSame([
+            'Number $a First number',
+            'Number $b Second number',
+        ], $doc->param);
 
-		// Property
-		$doc = new DocBlock($refl->getProperty("number"));
-		$this->assertSame("numeric", $doc->var);
-	}
+        // Different Default Result
+        $doc = new DocBlock($refl->getMethod('createFromString'));
+        $this->assertSame([], $doc->getTag('noSuchTag', []));
 
-	public function testGetTag() {
-		$doc = new DocBlock(new ReflectionClass("Number"));
-		$this->assertSame("v2.1-beta3", $doc->getTag("version"));
-		$this->assertSame([
-			"Mathable::add()",
-			"Mathable::subtract()",
-		], $doc->getTag("see"));
-	}
+        // Forced-array Result
+        $doc = new DocBlock($refl->getMethod('createFromString'));
+        $this->assertSame(['string $number'], $doc->getTag('param', null, true));
 
-	public function testGetTags() {
-		$doc = new DocBlock(new ReflectionClass("Number"));
-		$this->assertSame([
-			"version" => "v2.1-beta3",
-			"see" => [
-				"Mathable::add()",
-				"Mathable::subtract()",
-			],
-		], $doc->getTags());
-	}
+        // Trait-Imported Method
+        $doc = new DocBlock($refl->getMethod('add'));
+        $this->assertSame('object this', $doc->return);
 
-	public function testTagExists() {
-		$doc = new DocBlock(new ReflectionClass("Number"));
-		$this->assertTrue($doc->tagExists("see"));
-		$this->assertTrue($doc->tagExists("version"));
-		$this->assertFalse($doc->tagExists("deprecated"));
+        // Property
+        $doc = new DocBlock($refl->getProperty('number'));
+        $this->assertSame('numeric', $doc->var);
+        // One-line Property
+        $doc = new DocBlock($refl->getProperty('unusedNumber'));
+        $this->assertSame('numeric', $doc->var);
+    }
 
-		$num = new Number(1);
-		$refl = new ReflectionObject($num);
+    public function testGetTag()
+    {
+        $doc = new DocBlock(new ReflectionClass('Number'));
+        $this->assertSame('v2.1-beta3', $doc->getTag('version'));
+        $this->assertSame([
+            'Mathable::add()',
+            'Mathable::subtract()',
+        ], $doc->getTag('see'));
+    }
 
-		// Method
-		$doc = new DocBlock($refl->getMethod("value"));
-		$this->assertTrue($doc->tagExists("return"));
+    public function testGetTags()
+    {
+        $doc = new DocBlock(new ReflectionClass('Number'));
+        $this->assertSame([
+            'version' => 'v2.1-beta3',
+            'see' => [
+                'Mathable::add()',
+                'Mathable::subtract()',
+            ],
+        ], $doc->getTags());
+    }
 
-		// Property
-		$doc = new DocBlock($refl->getProperty("number"));
-		$this->assertTrue($doc->tagExists("var"));
+    public function testTagExists()
+    {
+        $doc = new DocBlock(new ReflectionClass('Number'));
+        $this->assertTrue($doc->tagExists('see'));
+        $this->assertTrue($doc->tagExists('version'));
+        $this->assertFalse($doc->tagExists('deprecated'));
 
-		// Trait-Imported Method
-		$doc = new DocBlock($refl->getMethod("subtract"));
-		$this->assertTrue($doc->tagExists("deprecated"));
-	}
+        $num = new Number(1);
+        $refl = new ReflectionObject($num);
 
+        // Method
+        $doc = new DocBlock($refl->getMethod('value'));
+        $this->assertTrue($doc->tagExists('return'));
+
+        // Property
+        $doc = new DocBlock($refl->getProperty('number'));
+        $this->assertTrue($doc->tagExists('var'));
+
+        // Trait-Imported Method
+        $doc = new DocBlock($refl->getMethod('subtract'));
+        $this->assertTrue($doc->tagExists('deprecated'));
+    }
 }


### PR DESCRIPTION
- Allow parsing from strings (instead of Reflector object only)
- Get method can be forced to return array of tags (common usage for param/property/method tags)
- Get method default result value can be changed (helpful when you want to iterate on result)
- Allows parsing of single-line docblocks
- Various minor code fixes; removed unused variables, standardized code style etc.
- Added php-cs-fixer dev dependency
